### PR TITLE
Fix default sample size for AudioEffectOpusChunked

### DIFF
--- a/src/audio_effect_opus_chunked.h
+++ b/src/audio_effect_opus_chunked.h
@@ -109,7 +109,7 @@ class AudioEffectOpusChunked : public AudioEffect {
     friend class AudioEffectOpusChunkedInstance;
 
     int audiosamplerate = 44100;
-    int audiosamplesize = 881;
+    int audiosamplesize = 882;
     int ringbufferchunks = 50;
 
     PackedVector2Array audiosamplebuffer;  // size audiosamplesize*ringbufferchunks


### PR DESCRIPTION
Uses a default audio sample size of 882 instead of 881 to match AudioStreamOpusChunked