### PR TITLE
Set TwoVoIP native version to 6.2.0

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define TWOVOIP_MAJOR 6
-#define TWOVOIP_MINOR 1
+#define TWOVOIP_MINOR 2
 #define TWOVOIP_PATCH 0
 #define TWOVOIP_VERSION ((TWOVOIP_MAJOR << (8 * 3)) + (TWOVOIP_MINOR << (8 * 2)) + (TWOVOIP_PATCH << (8 * 1)))
 


### PR DESCRIPTION
Follow-up release correction for PR #95: update the native version constant from 6.1.0 to 6.2.0 before tagging the v6.2 release. No other source or build behavior changes.