### PR TITLE
Expose gain as a writable Godot property

### DIFF
--- a/example/tests/v64_audio_processing_smoke.gd
+++ b/example/tests/v64_audio_processing_smoke.gd
@@ -25,12 +25,15 @@ func _initialize() -> void:
 	assert(encoder.get_required_input_chunk_size() == 882)
 	assert(encoder.get_current_chunk_16khz().is_empty())
 	assert(not encoder.has_method("fetch_pre_encoded_chunk"))
-	for property_name in ["output_chunk_size", "required_input_chunk_size", "gain", "agc_gain", "agc_mode", "denoiser", "peak", "rms", "speech_probability"]:
+	for property_name in ["output_chunk_size", "required_input_chunk_size", "agc_gain", "agc_mode", "denoiser", "peak", "rms", "speech_probability"]:
 		var property = encoder.get_property_list().filter(func(item): return item.name == property_name)
 		assert(property.size() == 1)
 		assert(property[0].usage & PROPERTY_USAGE_READ_ONLY)
+	var gain_property = encoder.get_property_list().filter(func(item): return item.name == "gain")
+	assert(gain_property.size() == 1)
+	assert(not (gain_property[0].usage & PROPERTY_USAGE_READ_ONLY))
 
-	encoder.set_gain(0.5)
+	encoder.gain = 0.5
 	var frames := make_stereo(882)
 	assert(encoder.process_chunk(frames) == 882)
 	assert(abs(encoder.get_gain() - 0.5) < 0.0001)

--- a/src/opus_encoder_object.cpp
+++ b/src/opus_encoder_object.cpp
@@ -63,7 +63,7 @@ void TwovoipOpusEncoder::_bind_methods() {
     uint32_t read_only = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
     ADD_PROPERTY(PropertyInfo(Variant::INT, "output_chunk_size", PROPERTY_HINT_NONE, "", read_only), "", "get_output_chunk_size");
     ADD_PROPERTY(PropertyInfo(Variant::INT, "required_input_chunk_size", PROPERTY_HINT_NONE, "", read_only), "", "get_required_input_chunk_size");
-    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gain", PROPERTY_HINT_NONE, "", read_only), "", "get_gain");
+    ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gain"), "set_gain", "get_gain");
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agc_gain", PROPERTY_HINT_NONE, "", read_only), "", "get_agc_gain");
     ADD_PROPERTY(PropertyInfo(Variant::INT, "denoiser", PROPERTY_HINT_ENUM, "Disabled,Speex,RNNoise", read_only), "", "get_denoiser");
     ADD_PROPERTY(PropertyInfo(Variant::INT, "agc_mode", PROPERTY_HINT_ENUM, "Disabled,Applied,Monitor", read_only), "", "get_agc_mode");


### PR DESCRIPTION
Corrects the v6.5 Godot binding so the existing set_gain()/get_gain() pair is represented by a writable Inspector property. Updates the Godot 4.6 smoke test to assign through encoder.gain and assert that the property is not read-only.\n\nValidated with the local native build and Godot 4.6 audio-processing smoke test.\n\nPrepared with assistance from OpenAI Codex, an AI coding agent based on GPT-5, under Julian Todd's direction and review.