### PR TITLE
Expose conditioned PCM for local loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,15 @@ var consumed := encoder.process_chunk(frames)
 if consumed >= 0:
     var peak := encoder.get_peak()
     var rms := encoder.get_rms()
+    var conditioned_pcm := encoder.get_current_chunk()
     var packet := encoder.encode_chunk()
 ```
+
+`get_current_chunk()` returns the processed output-rate PCM before Opus
+encoding as `PackedVector2Array` stereo frames. Mono processing is duplicated
+into both components so the result can be passed directly to a Godot audio
+stream. TwoVoIP does not retain a queue; callers that need delayed monitoring
+or non-network playback own that buffering.
 
 After a successful `process_chunk()`, `get_current_chunk_16khz()` returns the
 same processed time interval as mono 16 kHz floating-point PCM. It branches

--- a/doc_classes/TwovoipOpusEncoder.xml
+++ b/doc_classes/TwovoipOpusEncoder.xml
@@ -52,6 +52,10 @@
 			<return type="PackedFloat32Array" />
 			<description>Returns the last successfully processed chunk as post-processing mono 16 kHz PCM.</description>
 		</method>
+		<method name="get_current_chunk" qualifiers="const">
+			<return type="PackedVector2Array" />
+			<description>Returns the last processed output-rate PCM chunk as stereo frames, before Opus encoding.</description>
+		</method>
 		<method name="get_denoiser" qualifiers="const">
 			<return type="int" enum="TwovoipOpusEncoder.Denoiser" />
 			<description>Returns the configured denoiser.</description>
@@ -108,6 +112,7 @@
 		<member name="agc_gain" type="float" setter="" getter="get_agc_gain">Latest linear gain reported by Speex AGC.</member>
 		<member name="agc_mode" type="int" setter="" getter="get_agc_mode" enum="TwovoipOpusEncoder.AgcMode">Configured AGC mode.</member>
 		<member name="current_chunk_16khz" type="PackedFloat32Array" setter="" getter="get_current_chunk_16khz">Last processed post-processing mono 16 kHz PCM chunk.</member>
+		<member name="current_chunk" type="PackedVector2Array" setter="" getter="get_current_chunk">Last processed output-rate PCM chunk as stereo frames.</member>
 		<member name="denoiser" type="int" setter="" getter="get_denoiser" enum="TwovoipOpusEncoder.Denoiser">Configured denoiser.</member>
 		<member name="gain" type="float" setter="" getter="get_gain">Manual linear gain.</member>
 		<member name="output_chunk_size" type="int" setter="" getter="get_output_chunk_size">Output frames per chunk.</member>

--- a/src/opus_encoder_object.cpp
+++ b/src/opus_encoder_object.cpp
@@ -48,6 +48,7 @@ void TwovoipOpusEncoder::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_peak"), &TwovoipOpusEncoder::get_peak);
     ClassDB::bind_method(D_METHOD("get_rms"), &TwovoipOpusEncoder::get_rms);
     ClassDB::bind_method(D_METHOD("get_speech_probability"), &TwovoipOpusEncoder::get_speech_probability);
+    ClassDB::bind_method(D_METHOD("get_current_chunk"), &TwovoipOpusEncoder::get_current_chunk);
     ClassDB::bind_method(D_METHOD("get_current_chunk_16khz"), &TwovoipOpusEncoder::get_current_chunk_16khz);
     ClassDB::bind_method(D_METHOD("set_gain", "gain"), &TwovoipOpusEncoder::set_gain);
     ClassDB::bind_method(D_METHOD("get_gain"), &TwovoipOpusEncoder::get_gain);
@@ -70,6 +71,7 @@ void TwovoipOpusEncoder::_bind_methods() {
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "peak", PROPERTY_HINT_NONE, "", read_only), "", "get_peak");
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "rms", PROPERTY_HINT_NONE, "", read_only), "", "get_rms");
     ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speech_probability", PROPERTY_HINT_NONE, "", read_only), "", "get_speech_probability");
+    ADD_PROPERTY(PropertyInfo(Variant::PACKED_VECTOR2_ARRAY, "current_chunk", PROPERTY_HINT_NONE, "", read_only), "", "get_current_chunk");
     ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "current_chunk_16khz", PROPERTY_HINT_NONE, "", read_only), "", "get_current_chunk_16khz");
 
     BIND_ENUM_CONSTANT(DENOISER_DISABLED);
@@ -468,6 +470,21 @@ void TwovoipOpusEncoder::update_measurements() {
 
 int TwovoipOpusEncoder::process_chunk(const PackedVector2Array &audio_frames) {
     return process_chunk_internal(audio_frames);
+}
+
+PackedVector2Array TwovoipOpusEncoder::get_current_chunk() const {
+    PackedVector2Array frames;
+    frames.resize(output_chunk_size);
+    for (int frame = 0; frame < output_chunk_size; frame++) {
+        if (channels == 1) {
+            float sample = pre_encoded_chunk[frame];
+            frames.set(frame, Vector2(sample, sample));
+        } else {
+            int index = frame * 2;
+            frames.set(frame, Vector2(pre_encoded_chunk[index], pre_encoded_chunk[index + 1]));
+        }
+    }
+    return frames;
 }
 
 float TwovoipOpusEncoder::process_pre_encoded_chunk(PackedVector2Array audio_frames, int opus_chunk_size, bool speech_probability, bool rms) {

--- a/src/opus_encoder_object.h
+++ b/src/opus_encoder_object.h
@@ -136,6 +136,7 @@ public:
     float get_peak() const { return last_peak; }
     float get_rms() const { return last_rms; }
     float get_speech_probability() const { return last_speech_probability; }
+    PackedVector2Array get_current_chunk() const;
     PackedFloat32Array get_current_chunk_16khz() const { return current_chunk_16khz; }
     void set_gain(float p_gain);
     float get_gain() const { return gain; }


### PR DESCRIPTION
## Summary

- expose the most recently conditioned output-rate PCM before Opus encoding
- return Godot-ready stereo frames, duplicating mono into both channels
- document that delayed playback and buffering remain caller-owned
- add the read-only property to the generated editor documentation

This is intentionally independent of #100 and targets `main` directly. It does not change gain, preprocessing, Opus encoding, or the existing mono 16 kHz analysis hook.

## Verification

- Linux debug addon builds successfully with the documented NixOS/SCons route
- Godot 4.6 smoke test processes 960 input frames into 960 conditioned 48 kHz frames
- the same call exposes 320 post-processing mono 16 kHz analysis samples